### PR TITLE
Script de ejecución mejorado

### DIFF
--- a/rundevserver.sh
+++ b/rundevserver.sh
@@ -5,7 +5,10 @@ PUERTO_POR_DEFECTO=8080
 PUERTO_MIN=1023
 PUERTO_MAX=65536
 
-# Textos de error
+# Directorio
+DIRECTORIO_POR_DEFECTO="public"
+
+# Texto de ejemplo de uso
 EJEMPLO_USO="\nUso: $0 [-p <puerto>]"
 
 # Función para mostrar mensajes de error y terminar la ejecución
@@ -14,16 +17,37 @@ error() {
     exit 1
 }
 
+# Función de la opción -p
+obtener_puerto() {
+    if [[ $OPTARG -gt $PUERTO_MIN && $OPTARG -lt $PUERTO_MAX ]]; then
+        puerto=$OPTARG
+    else
+        error "-$opcion: el puerto debe estar comprendido entre $PUERTO_MIN y $PUERTO_MAX"
+    fi
+}
+
+# Función de la opción -d
+obtener_directorio() {
+    for d in */; do
+        if [[ $d == "$OPTARG/" ]]; then
+            directorio=$d
+            return
+        fi
+    done
+
+    error "-$opcion: el directorio '$OPTARG' no existe"
+}
+
 # Bucle que itera por cada opción recibida a la llamada del script
-while getopts ":p:" opcion; do
+while getopts ":p:d:" opcion; do
     case $opcion in
     # En caso de encontrar opción con argumento:
     p)
-        if [[ $OPTARG -gt $PUERTO_MIN && $OPTARG -lt $PUERTO_MAX ]]; then
-            puerto=$OPTARG
-        else
-            error "-$opcion: el puerto debe estar comprendido entre $PUERTO_MIN y $PUERTO_MAX"
-        fi
+        obtener_puerto
+        ;;
+
+    d)
+        obtener_directorio
         ;;
 
     # En cado de encontrar opción pero no argumento:
@@ -31,17 +55,13 @@ while getopts ":p:" opcion; do
         error "-${OPTARG}: requiere un argumento. $EJEMPLO_USO"
         ;;
 
-    # En caso de no encontrar una opción recogida en los parámetros:
+    # En caso de encontrar una opción que no esté recogida en los parámetros:
     *)
         error "-${OPTARG}: opción no encontrada. $EJEMPLO_USO"
         ;;
+
     esac
 done
-
-# En caso de no haber pasado ninguna opcion a la llamada del script:
-if [[ $OPTIND -eq 1 ]]; then
-    puerto=$PUERTO_POR_DEFECTO
-fi
 
 # Elimina los parámetros procesados por getopts
 # de los argumentos posicionales ($1, $2, $n...)
@@ -49,6 +69,11 @@ fi
 # utilizarlos más adelante en el código
 shift "$(($OPTIND-1))"
 
+# En caso de que alguna variable no haya sido pasada
+# por parámetro, se le asigna el valor por defecto:
+puerto="${puerto=$PUERTO_POR_DEFECTO}"
+directorio="${directorio=$DIRECTORIO_POR_DEFECTO}"
+
 # Ejecución del servidor local
-echo "Ejecutando servidor local en el puerto $puerto..."
-php -S localhost:$puerto -t public
+echo "Ejecutando servidor local en el puerto $puerto y en el directorio $directorio..."
+php -S localhost:$puerto -t $directorio

--- a/rundevserver.sh
+++ b/rundevserver.sh
@@ -1,9 +1,54 @@
 #!/bin/bash
 
-if [[ $1 -ne "" ]]; then
-    PORT=$1
-else
-    PORT=8000
+# Puertos
+PUERTO_POR_DEFECTO=8080
+PUERTO_MIN=1023
+PUERTO_MAX=65536
+
+# Textos de error
+EJEMPLO_USO="\nUso: $0 [-p <puerto>]"
+
+# Función para mostrar mensajes de error y terminar la ejecución
+error() {
+    echo -e "Error:\n$1"
+    exit 1
+}
+
+# Bucle que itera por cada opción recibida a la llamada del script
+while getopts ":p:" opcion; do
+    case $opcion in
+    # En caso de encontrar opción con argumento:
+    p)
+        if [[ $OPTARG -gt $PUERTO_MIN && $OPTARG -lt $PUERTO_MAX ]]; then
+            puerto=$OPTARG
+        else
+            error "-$opcion: el puerto debe estar comprendido entre $PUERTO_MIN y $PUERTO_MAX"
+        fi
+        ;;
+
+    # En cado de encontrar opción pero no argumento:
+    :)
+        error "-${OPTARG}: requiere un argumento. $EJEMPLO_USO"
+        ;;
+
+    # En caso de no encontrar una opción recogida en los parámetros:
+    *)
+        error "-${OPTARG}: opción no encontrada. $EJEMPLO_USO"
+        ;;
+    esac
+done
+
+# En caso de no haber pasado ninguna opcion a la llamada del script:
+if [[ $OPTIND -eq 1 ]]; then
+    puerto=$PUERTO_POR_DEFECTO
 fi
 
-php -S localhost:$PORT -t public
+# Elimina los parámetros procesados por getopts
+# de los argumentos posicionales ($1, $2, $n...)
+# para que no haya problemas a la hora de querer
+# utilizarlos más adelante en el código
+shift "$(($OPTIND-1))"
+
+# Ejecución del servidor local
+echo "Ejecutando servidor local en el puerto $puerto..."
+php -S localhost:$puerto -t public


### PR DESCRIPTION
He mejorado el script para que se le puedan pasar opciones con argumentos. En caso de querer añadir más opciones, tan solo habría que añadirlo en el string del bucle _while_ , y añadir una opción en el _switch_.

Nunca antes hacer un script de bash me había dado tantas ganas de querer arrancarme las cuencas de los ojos con una cuchara de madera, no intentéis entender bash en la franja horaria comprendida de 3:00 AM a 4:00 AM, peor decisión de mi vida.

PD: He visto que se me ha olvidado actualizar el texto de ejemplo de uso, por no llenar esto de commits porque soy un olvidadizo mejor lo pongo aquí: 
```bash
# Texto de ejemplo de uso
EJEMPLO_USO="\nUso: $0 [-p <puerto> | -d <directorio>]"
```